### PR TITLE
Use upstream VirtualBox repo and clarify README

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,6 +65,7 @@ chmod +x fedora_security_setup_interactive.sh
 - The script uses `dnf` and `flatpak` (where applicable).
 - SELinux is enforced and Secure Boot is supported by default.
 - Script sets `zsh` as the default shell and prepares for dotfile syncing.
+- Upstream virtualization installs may require additional GPG keys.
 
 ---
 

--- a/fedora_security_setup_interactive.sh
+++ b/fedora_security_setup_interactive.sh
@@ -220,15 +220,10 @@ install_fallback() {
       ;;
     virtualbox)
       echo -e "${YELLOW}⚠️ Installing VirtualBox from Oracle repository...${RESET}"
-      sudo bash -c 'cat > /etc/yum.repos.d/virtualbox.repo <<"EOF"
-[virtualbox]
-name=VirtualBox for Fedora $releasever - $basearch
-baseurl=https://download.virtualbox.org/virtualbox/rpm/fedora/$releasever/$basearch
-enabled=1
-gpgcheck=1
-gpgkey=https://www.virtualbox.org/download/oracle_vbox.asc
-EOF'
-      if sudo dnf5 install -y VirtualBox; then
+      sudo wget -O /etc/yum.repos.d/virtualbox.repo https://download.virtualbox.org/virtualbox/rpm/fedora/virtualbox.repo
+      sudo rpm --import https://www.virtualbox.org/download/oracle_vbox.asc
+      sudo rpm --import https://www.virtualbox.org/download/oracle_vbox_2016.asc
+      if sudo dnf5 install -y VirtualBox-7.0; then
         install_status["virtualbox"]="✅ Installed via fallback"
       else
         install_status["virtualbox"]="❌ Fallback Failed"


### PR DESCRIPTION
## Summary
- fetch official VirtualBox repository instead of a custom block
- import both Oracle GPG keys and install VirtualBox 7.0
- document VirtualBox GPG key requirement in README

## Testing
- `bash -n fedora_security_setup_interactive.sh`
- `./fedora_security_setup_interactive.sh --help | head -n 5`

------
https://chatgpt.com/codex/tasks/task_e_68469897ab008324bb2aadaf78ca4f93